### PR TITLE
Fix feed tab redirect to create tab

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -63,11 +63,6 @@ export default function HomePage() {
   const [moments, setMoments] = useState<SharedMoment[]>([])
   const [loading, setLoading] = useState(true)
 
-  // Redirect to share tab by default
-  useEffect(() => {
-    router.push('/create')
-  }, [router])
-
   useEffect(() => {
     const fetchMoments = async () => {
       try {
@@ -101,6 +96,7 @@ export default function HomePage() {
             })),
             engagement: {
               likes: Math.floor(Math.random() * 50) + 1, // Mock engagement data for now
+              comments: Math.floor(Math.random() * 20), // Add comments count
               isLikedByUser: false
             },
             createdAt: new Date(apiMoment.created_at).toLocaleDateString()
@@ -121,6 +117,12 @@ export default function HomePage() {
     fetchMoments()
   }, [])
 
-  // Don't render anything while redirecting to share tab
-  return null
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <main className="pb-16">
+        <SocialFeed moments={moments} loading={loading} />
+      </main>
+      <BottomNavigation />
+    </div>
+  )
 }


### PR DESCRIPTION
Remove automatic redirect from feed tab to create tab and render the social feed on the root path.

Previously, the root path (`/`), which corresponds to the Feed tab, would immediately redirect users to `/create`. This prevented users from viewing the social feed and made the Feed tab unusable. This PR fixes the navigation by rendering the `SocialFeed` component on the root path and removing the redirect, allowing users to navigate to and view the feed.

---
<a href="https://cursor.com/background-agent?bcId=bc-2219dd3f-18b7-4145-a1a6-95433bdb3d9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2219dd3f-18b7-4145-a1a6-95433bdb3d9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

