### PR TITLE
Fix feed tab redirect to create tab

### DIFF
--- a/__tests__/pages/home.test.tsx
+++ b/__tests__/pages/home.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/react'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import HomePage from '@/app/page'
 
 // Mock Next.js navigation
 jest.mock('next/navigation', () => ({
-  usePathname: jest.fn()
+  usePathname: jest.fn(),
+  useRouter: jest.fn()
 }))
 
 // Mock components
@@ -17,10 +18,20 @@ jest.mock('@/components/social-feed', () => ({
 }))
 
 const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+const mockPush = jest.fn()
 
 describe('HomePage', () => {
   beforeEach(() => {
     mockUsePathname.mockReturnValue('/')
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+      back: jest.fn(),
+      forward: jest.fn(),
+      refresh: jest.fn(),
+      replace: jest.fn(),
+      prefetch: jest.fn()
+    } as any)
   })
 
   it('renders the home page with header', () => {


### PR DESCRIPTION
Allow navigation to the Feed tab by removing the unconditional redirect to Create, while maintaining initial focus on Create per session.

---
<a href="https://cursor.com/background-agent?bcId=bc-9feaf051-38d8-4131-ab17-d3fe546f7713">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9feaf051-38d8-4131-ab17-d3fe546f7713">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

